### PR TITLE
Added customization for library: font, textPosition

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@ This project is licensed under the MIT License.
 
 
 ## Additions
-I have added a few more props to make the wheel more cutomizable:
+I have added a few more props to make the wheel more customizable:
 `font`, `textPosition`, `textColor` in `slices`, so the props become (added ones are on the top):
 | Prop                        | Type   | Default          | Description                                                                          |
 |-----------------------------|--------|------------------|--------------------------------------------------------------------------------------|

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,8 @@ Import and register the component in your Vue component:
   <VueWheelSpinner
       ref="spinner"
       :slices="slices"
+      :slice-font-style="sliceFontStyle"
+      :slice-text-position="sliceTextPosition"
       :winner-index="defaultWinner"
       :sounds="sounds"
       :cursor-angle="cursorAngle"
@@ -88,13 +90,15 @@ Import and register the component in your Vue component:
       return {
         winnerResult: null,
         slices: [
-          {color: '#eb4d4b', text: 'Slice 1'},
-          {color: '#f0932b', text: 'Slice 2'},
-          {color: '#f9ca24', text: 'Slice 3'},
-          {color: '#badc58', text: 'Slice 4'},
-          {color: '#7ed6df', text: 'Slice 5'},
-          {color: '#e056fd', text: 'Slice 6'}
+          {color: '#eb4d4b', text: 'Slice 1', textColor: '#000000'},
+          {color: '#f0932b', text: 'Slice 2', textColor: '#ffffff'},
+          {color: '#f9ca24', text: 'Slice 3', textColor: '#000000'},
+          {color: '#badc58', text: 'Slice 4', textColor: '#ffffff'},
+          {color: '#7ed6df', text: 'Slice 5', textColor: '#000000'},
+          {color: '#e056fd', text: 'Slice 6', textColor: '#ffffff'},
         ],
+        sliceFontStyle: 'bold 16px Arial',
+        sliceTextPosition: 'edge',
         isSpinning: false,
         defaultWinner: 0,
         sounds: {
@@ -207,6 +211,8 @@ Import and register the component in your Vue component:
 | Prop                        | Type   | Default    | Description                                                                          |
 |-----------------------------|--------|------------|--------------------------------------------------------------------------------------|
 | `slices`                    | Array  | required   | Array of slice objects. Each slice object should have `color` and `text` properties. |
+| `sliceFontStyle`            | String | 'bold 16px Arial' | Font style for the slice text.                                                       |
+| `sliceTextPosition`         | String | 'edge'     | Position of the slice text. Can be 'edge', 'center' or 'middle'.                      |
 | `winnerIndex`               | Number | 0          | Index of the slice that will be the winner.                                          |
 | `spinDuration`              | Number | 4000       | Duration of the spin animation in milliseconds.                                      |
 | `cursorAngle`               | Number | 0          | Angle of the cursor.                                                                 |
@@ -233,22 +239,3 @@ Import and register the component in your Vue component:
 
 ## License
 This project is licensed under the MIT License.
-
-
-## Additions
-I have added a few more props to make the wheel more customizable:
-`font`, `textPosition`, `textColor` in `slices`, so the props become (added ones are on the top):
-| Prop                        | Type   | Default          | Description                                                                          |
-|-----------------------------|--------|------------------|--------------------------------------------------------------------------------------|
-| `font`                      | String | 'bold 16px Arial'| includes the font-weight, font-size, font-family. Takes 'bold 16px Arial' by default.|
-| `textPosition`              | String | 'edge'           | Position of the text on the slice. Can be 'edge', 'middle', 'center'.                |
-| `slices`                    | Array  | required         | Array of slice objects. Each slice object should have `color` and `text` properties. |
-|                             |        |                  |`textColor` is not required. If not added, the contrast of `color` will be default.   |
-| `winnerIndex`               | Number | 0                | Index of the slice that will be the winner.                                          |
-| `spinDuration`              | Number | 4000             | Duration of the spin animation in milliseconds.                                      |
-| `cursorAngle`               | Number | 0                | Angle of the cursor.                                                                 |
-| `cursorPosition`            | String | 'edge'           | Position of the cursor. Can be 'edge' or 'center'.                                   |
-| `cursorDistance`            | Number | 0                | Distance of the cursor from the center or edge. It's depending to cursorPosition     |
-| `sounds`                    | Object | {}               | Object of sound files.                                                               |
-| `sounds.won`                | String | null             | Sound file for the winning event.                                                    |
-| `sounds.spinning`           | String | null             | Sound file for the spinning event.                                                   |

--- a/readme.md
+++ b/readme.md
@@ -233,3 +233,22 @@ Import and register the component in your Vue component:
 
 ## License
 This project is licensed under the MIT License.
+
+
+## Additions
+I have added a few more props to make the wheel more cutomizable:
+`font`, `textPosition`, `textColor` in `slices`, so the props become (added ones are on the top):
+| Prop                        | Type   | Default          | Description                                                                          |
+|-----------------------------|--------|------------------|--------------------------------------------------------------------------------------|
+| `font`                      | String | 'bold 16px Arial'| includes the font-weight, font-size, font-family. Takes 'bold 16px Arial' by default.|
+| `textPosition`              | String | 'edge'           | Position of the text on the slice. Can be 'edge', 'middle', 'center'.                |
+| `slices`                    | Array  | required         | Array of slice objects. Each slice object should have `color` and `text` properties. |
+|                             |        |                  |`textColor` is not required. If not added, the contrast of `color` will be default.   |
+| `winnerIndex`               | Number | 0                | Index of the slice that will be the winner.                                          |
+| `spinDuration`              | Number | 4000             | Duration of the spin animation in milliseconds.                                      |
+| `cursorAngle`               | Number | 0                | Angle of the cursor.                                                                 |
+| `cursorPosition`            | String | 'edge'           | Position of the cursor. Can be 'edge' or 'center'.                                   |
+| `cursorDistance`            | Number | 0                | Distance of the cursor from the center or edge. It's depending to cursorPosition     |
+| `sounds`                    | Object | {}               | Object of sound files.                                                               |
+| `sounds.won`                | String | null             | Sound file for the winning event.                                                    |
+| `sounds.spinning`           | String | null             | Sound file for the spinning event.                                                   |

--- a/src/components/VueWheelSpinner.vue
+++ b/src/components/VueWheelSpinner.vue
@@ -31,6 +31,14 @@ const props = defineProps({
     type: Array,
     required: true
   },
+  sliceFontStyle: {
+    type: String,
+    default: 'bold 16px Arial'
+  },
+  sliceTextPosition: {
+    type: String,
+    default: 'edge'
+  },
   winnerIndex: {
     type: Number,
     default: 0
@@ -63,14 +71,6 @@ const props = defineProps({
         won: () => null
       }
     }
-  },
-  font: {
-    type: String,
-    default: 'bold 16px Arial'
-  },
-  textPosition: {
-    type: String,
-    default: 'edge'
   },
 });
 
@@ -146,25 +146,23 @@ function drawSlice(context, centerX, centerY, radius, startAngle, endAngle, fill
   context.save();
 }
 
-function drawLabel(context, centerX, centerY, radius, startAngle, endAngle, fillColor, sliceLabel, textColor, textPosition, font) {
+function drawLabel(context, centerX, centerY, radius, startAngle, endAngle, fillColor, sliceLabel, sliceTextColor, sliceTextPosition, sliceFontStyle) {
   // Draw label
   const textRotateAngle = (endAngle - startAngle) / 2 + startAngle;
   context.translate(centerX, centerY);
   context.rotate(degreesToRadians(textRotateAngle));
   context.textAlign = 'right';
   context.textBaseline = 'middle';
-  context.fillStyle = textColor || getContrastingColor(fillColor);
-  context.font = font;
-  if (textPosition === 'edge') {
-    context.fillText(sliceLabel, radius - 10 , 0);
-  } else if (textPosition === 'center') {
-    context.fillText(sliceLabel, 3 * radius / 4 , 0);
-  }
-  else if (textPosition === 'middle') {
-    context.fillText(sliceLabel, radius / 2 , 0);
-  }
-  else {
-    context.fillText(sliceLabel, radius - 10 , 0);
+  context.fillStyle = sliceTextColor || getContrastingColor(fillColor);
+  context.font = sliceFontStyle;
+  if (sliceTextPosition === 'edge') {
+    context.fillText(sliceLabel, radius - 10, 0);
+  } else if (sliceTextPosition === 'center') {
+    context.fillText(sliceLabel, 3 * radius / 4, 0);
+  } else if (sliceTextPosition === 'middle') {
+    context.fillText(sliceLabel, radius / 2, 0);
+  } else {
+    context.fillText(sliceLabel, radius - 10, 0);
   }
   context.restore();
 }
@@ -215,7 +213,7 @@ function drawWheel() {
     drawSlice(context, centerX, centerY, radius, startAngle, endAngle, slice.color);
 
     // Draw slice label
-    drawLabel(context, centerX, centerY, radius, startAngle, endAngle, slice.color, slice.text, slice.textColor, props.textPosition, props.font);
+    drawLabel(context, centerX, centerY, radius, startAngle, endAngle, slice.color, slice.text, slice.textColor, props.sliceTextPosition, props.sliceFontStyle);
 
   });
 
@@ -387,6 +385,14 @@ watch(() => props.cursorPosition, () => {
 
 watch(() => props.cursorDistance, () => {
   positionCursor();
+});
+
+watch(() => props.sliceTextPosition, () => {
+  drawWheel();
+});
+
+watch(() => props.sliceFontStyle, () => {
+  drawWheel();
 });
 
 onBeforeMount(() => {

--- a/src/components/VueWheelSpinner.vue
+++ b/src/components/VueWheelSpinner.vue
@@ -64,6 +64,14 @@ const props = defineProps({
       }
     }
   },
+  font: {
+    type: String,
+    default: 'bold 16px Arial'
+  },
+  textPosition: {
+    type: String,
+    default: 'right'
+  },
 });
 
 function degreesToRadians(degrees) {
@@ -138,16 +146,26 @@ function drawSlice(context, centerX, centerY, radius, startAngle, endAngle, fill
   context.save();
 }
 
-function drawLabel(context, centerX, centerY, radius, startAngle, endAngle, fillColor, sliceLabel) {
+function drawLabel(context, centerX, centerY, radius, startAngle, endAngle, fillColor, sliceLabel, textColor, textPosition, font) {
   // Draw label
   const textRotateAngle = (endAngle - startAngle) / 2 + startAngle;
   context.translate(centerX, centerY);
   context.rotate(degreesToRadians(textRotateAngle));
   context.textAlign = 'right';
   context.textBaseline = 'middle';
-  context.fillStyle = getContrastingColor(fillColor);
-  context.font = 'bold 16px Arial';
-  context.fillText(sliceLabel, radius - 10, 0);
+  context.fillStyle = textColor || getContrastingColor(fillColor);
+  context.font = font;
+  if (textPosition === 'edge') {
+    context.fillText(sliceLabel, radius - 10 , 0);
+  } else if (textPosition === 'center') {
+    context.fillText(sliceLabel, 3 * radius / 4 , 0);
+  }
+  else if (textPosition === 'middle') {
+    context.fillText(sliceLabel, radius / 2 , 0);
+  }
+  else {
+    context.fillText(sliceLabel, radius - 10 , 0);
+  }
   context.restore();
 }
 
@@ -197,7 +215,7 @@ function drawWheel() {
     drawSlice(context, centerX, centerY, radius, startAngle, endAngle, slice.color);
 
     // Draw slice label
-    drawLabel(context, centerX, centerY, radius, startAngle, endAngle, slice.color, slice.text);
+    drawLabel(context, centerX, centerY, radius, startAngle, endAngle, slice.color, slice.text, slice.textColor, props.textPosition, props.font);
 
   });
 

--- a/src/components/VueWheelSpinner.vue
+++ b/src/components/VueWheelSpinner.vue
@@ -70,7 +70,7 @@ const props = defineProps({
   },
   textPosition: {
     type: String,
-    default: 'right'
+    default: 'edge'
   },
 });
 


### PR DESCRIPTION
I have added a few more props to make the wheel more cutomizable:
`font`, `textPosition`, `textColor` in `slices`, so the added props become:
| `font`                | String | 'bold 16px Arial'| includes the font-weight, font-size, font-family. Takes 'bold 16px Arial' by default.|
| `textPosition`   | String | 'edge'                 | Position of the text on the slice. Can be 'edge', 'middle', 'center'.                            |
| `slices`              | Array  | required             | Array of slice objects. Each slice object should have `color` and `text` properties.`textColor` is not required. If not added, the contrast of `color` will be default.                                                          |